### PR TITLE
Add a config parameter to choose cxs mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,8 @@ config.set({
     0, 6, 12, 24, 48
   ],
   radius: 3,
-  bold: 600
+  bold: 600,
+  mode: 'atomic'
 })
 ```
 

--- a/src/config.js
+++ b/src/config.js
@@ -57,6 +57,12 @@ Object.defineProperty(config, 'bold', {
   }
 })
 
+Object.defineProperty(config, 'mode', {
+  get () {
+    return config.get().mode
+  }
+})
+
 export { defaultConfig as defaultConfig } from 'understyle'
 
 export default config

--- a/src/parse-props.js
+++ b/src/parse-props.js
@@ -1,5 +1,7 @@
 
-import cxs from 'cxs'
+import cxsAtomic from 'cxs/atomic'
+import cxsLite from 'cxs/lite'
+import cxsMonolithic from 'cxs/monolithic'
 import { createUnderstyle, filterProps } from 'understyle'
 import classnames from 'classnames'
 import merge from 'deepmerge'
@@ -30,7 +32,17 @@ const parseProps = (original = {}) => {
     (original.css || {}),
   ])
 
-  const cxsClassName = cxs(styles)
+  let cxsClassName
+  switch (options.mode) {
+    case 'lite':
+      cxsClassName = cxsLite(styles)
+      break;
+    case 'monolithic':
+      cxsClassName = cxsMonolithic(styles)
+      break;
+    default:
+      cxsClassName = cxsAtomic(styles)
+  }
 
   const className = classnames(original.className, cxsClassName)
 


### PR DESCRIPTION
```js
import { config } from 'axs'

config.set({
  mode: 'lite'
})
```

Use `cxs` atomic by default. Possible values: `atomic, lite, monolithic`

--- 
The `mode` config is passed to `understyle`. 
Should I omit it? Even though I don't think that something is wrong with it.